### PR TITLE
Rework transition execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ Changelog
 [Unreleased]
 ------------
 
+### Added
+
+ - Add `Netzmacht\Workflow\Flow\Transition\AbstractTransition`
+ - Add `Transition#execute` method
+ 
+### Changed
+
+ - Use `Transition#execute` in the transition handler
+
+### Breaking
+
+ - Rename `Transition` to `ActionBasedTransition`
+ - `Transition` is now an interface
+
 ### Fixed
 
  - Fix initial value of item state

--- a/spec/Flow/Transition/ActionBasedTransitionSpec.php
+++ b/spec/Flow/Transition/ActionBasedTransitionSpec.php
@@ -30,7 +30,7 @@ use Prophecy\Argument;
  *
  * @package spec\Netzmacht\Workflow\Flow
  */
-class TransitionSpec extends ObjectBehavior
+class ActionBasedTransitionSpec extends ObjectBehavior
 {
     private const NAME = 'transition_name';
 

--- a/spec/Flow/TransitionSpec.php
+++ b/spec/Flow/TransitionSpec.php
@@ -336,6 +336,32 @@ class TransitionSpec extends ObjectBehavior
         $this->isAvailable($item, $context, $errorCollection)->shouldReturn(true);
     }
 
+    function it_executes_transition_(
+        Item $item,
+        Context $context,
+        ErrorCollection $errorCollection,
+        Action $action,
+        Action $postAction
+    ) {
+        $context->getErrorCollection()->willReturn($errorCollection);
+        $errorCollection->hasErrors()->willReturn(false);
+
+        $this->addAction($action);
+        $this->addPostAction($postAction);
+
+        $action->transit($this->getWrappedObject(), $item, $context)->shouldBeCalledOnce();
+        $postAction->transit($this->getWrappedObject(), $item, $context)->shouldBeCalledOnce();
+
+        $item->isWorkflowStarted()
+            ->shouldBeCalled()
+            ->willReturn(true);
+
+        $item->transit($this->getWrappedObject(), $context, true)
+            ->shouldBeCalled();
+
+        $this->execute($item, $context);
+    }
+
     function it_executes_actions(
         Item $item,
         Context $context,

--- a/spec/Handler/RepositoryBasedTransitionHandlerSpec.php
+++ b/spec/Handler/RepositoryBasedTransitionHandlerSpec.php
@@ -241,20 +241,12 @@ class RepositoryBasedTransitionHandlerSpec extends ObjectBehavior
 
     function it_transits_to_next_state(Transition $transition, Item $item, State $state)
     {
-        $item->transit($transition, Argument::type(Context::class), true)
-            ->shouldBeCalled()
-            ->willReturn($state);
-
         $transition->validate($item, Argument::type(Context::class))
             ->willReturn(true)
             ->shouldBeCalled();
 
-        $transition->executeActions($item, Argument::type(Context::class))
-            ->willReturn(true)
-            ->shouldBeCalled();
-
-        $transition->executePostActions($item, Argument::type(Context::class))
-            ->willReturn(true)
+        $transition->execute($item, Argument::type(Context::class))
+            ->willReturn($state)
             ->shouldBeCalled();
 
         $transition->checkCondition($item, Argument::type(Context::class))
@@ -266,7 +258,7 @@ class RepositoryBasedTransitionHandlerSpec extends ObjectBehavior
             ->shouldBeCalled();
 
         $this->validate([]);
-        $this->transit()->shouldHaveType('Netzmacht\Workflow\Flow\State');
+        $this->transit()->shouldHaveType(State::class);
     }
 
     function it_checks_if_transition_is_available(Transition $transition, Item $item)

--- a/src/Flow/Transition/AbstractTransition.php
+++ b/src/Flow/Transition/AbstractTransition.php
@@ -1,0 +1,252 @@
+<?php
+
+/**
+ * Workflow library.
+ *
+ * @package    workflow
+ * @author     David Molineus <david.molineus@netzmacht.de>
+ * @copyright  2014-2019 netzmacht David Molineus
+ * @license    LGPL 3.0-or-later https://github.com/netzmacht/workflow/blob/master/LICENSE
+ * @filesource
+ */
+
+declare(strict_types=1);
+
+namespace Netzmacht\Workflow\Flow\Transition;
+
+use Netzmacht\Workflow\Flow\Action;
+use Netzmacht\Workflow\Flow\Base;
+use Netzmacht\Workflow\Flow\Condition\Transition\Condition;
+use Netzmacht\Workflow\Flow\Condition\Transition\AndCondition;
+use Netzmacht\Workflow\Flow\Context;
+use Netzmacht\Workflow\Flow\Item;
+use Netzmacht\Workflow\Flow\Security\Permission;
+use Netzmacht\Workflow\Flow\Step;
+use Netzmacht\Workflow\Flow\Transition;
+use Netzmacht\Workflow\Flow\Workflow;
+
+/**
+ * Base transition implementation
+ */
+abstract class AbstractTransition extends Base implements Transition
+{
+    /**
+     * The step the transition is moving to.
+     *
+     * @var Step
+     */
+    private $stepTo;
+
+    /**
+     * A pre condition which has to be passed to execute transition.
+     *
+     * @var AndCondition
+     */
+    private $preCondition;
+
+    /**
+     * A condition which has to be passed to execute the transition.
+     *
+     * @var AndCondition
+     */
+    private $condition;
+
+    /**
+     * A set of permission being assigned to the transition.
+     *
+     * @var Permission|null
+     */
+    private $permission;
+
+    /**
+     * The corresponding workflow.
+     *
+     * @var Workflow
+     */
+    private $workflow;
+
+    /**
+     * Transition constructor.
+     *
+     * @param string    $name     Name of the element.
+     * @param Workflow  $workflow The workflow to which the transition belongs.
+     * @param Step|null $stepTo   The target step.
+     * @param string    $label    Label of the element.
+     * @param array     $config   Configuration values.
+     */
+    public function __construct(string $name, Workflow $workflow, ?Step $stepTo, string $label = '', array $config = [])
+    {
+        parent::__construct($name, $label, $config);
+
+        $workflow->addTransition($this);
+
+        $this->workflow = $workflow;
+        $this->stepTo   = $stepTo;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getWorkflow(): Workflow
+    {
+        return $this->workflow;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStepTo():? Step
+    {
+        return $this->stepTo;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCondition():? Condition
+    {
+        return $this->condition;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addCondition(Condition $condition): Transition
+    {
+        if (!$this->condition) {
+            $this->condition = new AndCondition();
+        }
+        $this->condition->addCondition($condition);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPreCondition():? Condition
+    {
+        return $this->preCondition;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addPreCondition(Condition $preCondition): Transition
+    {
+        if (!$this->preCondition) {
+            $this->preCondition = new AndCondition();
+        }
+
+        $this->preCondition->addCondition($preCondition);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRequiredPayloadProperties(Item $item): array
+    {
+        if (empty($this->actions)) {
+            return [];
+        }
+
+        return array_merge(
+            ... array_map(
+                function (Action $action) use ($item) {
+                    return $action->getRequiredPayloadProperties($item);
+                },
+                $this->actions
+            )
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isAllowed(Item $item, Context $context): bool
+    {
+        if ($this->checkPreCondition($item, $context)) {
+            return $this->checkCondition($item, $context);
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isAvailable(Item $item, Context $context): bool
+    {
+        if ($this->getRequiredPayloadProperties($item)) {
+            return $this->checkPreCondition($item, $context);
+        }
+
+        return $this->isAllowed($item, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function checkPreCondition(Item $item, Context $context): bool
+    {
+        return $this->performConditionCheck($this->preCondition, $item, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function checkCondition(Item $item, Context $context): bool
+    {
+        return $this->performConditionCheck($this->condition, $item, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setPermission(Permission $permission): Transition
+    {
+        $this->permission = $permission;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasPermission(Permission $permission): bool
+    {
+        if ($this->permission) {
+            return $this->permission->equals($permission);
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPermission():? Permission
+    {
+        return $this->permission;
+    }
+
+    /**
+     * Perform condition check.
+     *
+     * @param Condition|null $condition Condition to be checked.
+     * @param Item           $item      Workflow item.
+     * @param Context        $context   Condition context.
+     *
+     * @return bool
+     */
+    private function performConditionCheck(?Condition $condition, $item, $context): bool
+    {
+        if (!$condition) {
+            return true;
+        }
+
+        return $condition->match($this, $item, $context);
+    }
+}

--- a/src/Flow/Transition/ActionBasedTransition.php
+++ b/src/Flow/Transition/ActionBasedTransition.php
@@ -1,0 +1,200 @@
+<?php
+
+/**
+ * Workflow library.
+ *
+ * @package    workflow
+ * @author     David Molineus <david.molineus@netzmacht.de>
+ * @copyright  2014-2017 netzmacht David Molineus
+ * @license    LGPL 3.0 https://github.com/netzmacht/workflow
+ * @filesource
+ */
+
+declare(strict_types=1);
+
+namespace Netzmacht\Workflow\Flow\Transition;
+
+use Netzmacht\Workflow\Flow\Action;
+use Netzmacht\Workflow\Flow\Context;
+use Netzmacht\Workflow\Flow\Exception\ActionFailedException;
+use Netzmacht\Workflow\Flow\Item;
+use Netzmacht\Workflow\Flow\State;
+
+/**
+ * Class Transition handles the transition from a step to another.
+ *
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ */
+class ActionBasedTransition extends AbstractTransition
+{
+    /**
+     * Actions which will be executed during the transition.
+     *
+     * @var Action[]
+     */
+    private $actions = [];
+
+    /**
+     * Post actions which will be executed when new step is reached.
+     *
+     * @var Action[]
+     */
+    private $postActions = [];
+
+    /**
+     * Add an action to the transition.
+     *
+     * @param Action $action The added action.
+     *
+     * @return $this
+     */
+    public function addAction(Action $action): self
+    {
+        $this->actions[] = $action;
+
+        return $this;
+    }
+
+    /**
+     * Get all actions.
+     *
+     * @return Action[]|iterable
+     */
+    public function getActions(): iterable
+    {
+        return $this->actions;
+    }
+
+    /**
+     * Add an post action to the transition.
+     *
+     * @param Action $action The added action.
+     *
+     * @return $this
+     */
+    public function addPostAction(Action $action): self
+    {
+        $this->postActions[] = $action;
+
+        return $this;
+    }
+
+    /**
+     * Get all post actions.
+     *
+     * @return Action[]|iterable
+     */
+    public function getPostActions(): iterable
+    {
+        return $this->postActions;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRequiredPayloadProperties(Item $item): array
+    {
+        if (empty($this->actions)) {
+            return [];
+        }
+
+        return array_merge(
+            ... array_map(
+                function (Action $action) use ($item) {
+                    return $action->getRequiredPayloadProperties($item);
+                },
+                $this->actions
+            )
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate(Item $item, Context $context): bool
+    {
+        $validated = true;
+
+        foreach ($this->actions as $action) {
+            $validated = $validated && $action->validate($item, $context);
+        }
+
+        return $validated;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(Item $item, Context $context) : State
+    {
+        $success = $this->executeActions($item, $context);
+
+        if ($item->isWorkflowStarted()) {
+            $state = $item->transit($this, $context, $success);
+        } else {
+            $state = $item->start($this, $context, $success);
+        }
+
+        $this->executePostActions($item, $context);
+
+        return $state;
+    }
+
+    /**
+     * Execute all actions.
+     *
+     * @param Item    $item    The workflow item.
+     * @param Context $context The transition context.
+     *
+     * @return bool
+     */
+    public function executeActions(Item $item, Context $context): bool
+    {
+        return $this->doExecuteActions($item, $context, $this->actions);
+    }
+
+    /**
+     * Execute all actions.
+     *
+     * @param Item    $item    The workflow item.
+     * @param Context $context The transition context.
+     *
+     * @return bool
+     */
+    public function executePostActions(Item $item, Context $context): bool
+    {
+        return $this->doExecuteActions($item, $context, $this->postActions);
+    }
+
+    /**
+     * Execute the actions.
+     *
+     * @param Item     $item    Workflow item.
+     * @param Context  $context Condition context.
+     * @param Action[] $actions Action to execute.
+     *
+     * @return bool
+     */
+    private function doExecuteActions(Item $item, Context $context, $actions): bool
+    {
+        $success = $this->isAllowed($item, $context);
+
+        if ($success) {
+            try {
+                foreach ($actions as $action) {
+                    $action->transit($this, $item, $context);
+                }
+            } catch (ActionFailedException $e) {
+                $params = [
+                    'exception' => $e->getMessage(),
+                    'action'    => $e->actionName()
+                ];
+                $context->addError('transition.action.failed', $params, $e->errorCollection());
+
+                return false;
+            }
+        }
+
+        return $success && !$context->getErrorCollection()->hasErrors();
+    }
+}

--- a/src/Handler/AbstractTransitionHandler.php
+++ b/src/Handler/AbstractTransitionHandler.php
@@ -207,18 +207,7 @@ abstract class AbstractTransitionHandler implements TransitionHandler
      */
     protected function executeTransition(): State
     {
-        $transition = $this->getTransition();
-        $success    = $transition->executeActions($this->item, $this->context);
-
-        if ($this->isWorkflowStarted()) {
-            $state = $this->getItem()->transit($transition, $this->context, $success);
-        } else {
-            $state = $this->getItem()->start($transition, $this->context, $success);
-        }
-
-        $transition->executePostActions($this->item, $this->context);
-
-        return $state;
+        return $this->getTransition()->execute($this->item, $this->context);
     }
 
     /**


### PR DESCRIPTION
This pull request reworks the transition execution

 - [x] Introduce new method `Transition#execute`
 - [x] Allow not to define a target step in the `Transition`
 - [x] Transition handler should use the new introduced method  `Transition#execute`
 - [ ] `Transition#getStepTo` is return value as `Step|null` but might leads to null pointer exceptions as not properly handled