### PR TITLE
Add spec for preferred requirement

### DIFF
--- a/spec/Manager/WorkflowManagerSpec.php
+++ b/spec/Manager/WorkflowManagerSpec.php
@@ -239,4 +239,28 @@ class WorkflowManagerSpec extends ObjectBehavior
         $this->createItem($entityId, static::$entity)->shouldHaveType('Netzmacht\Workflow\Flow\Item');
     }
 
+    function it_prefers_current_workflow_by_item(
+        TransitionHandlerFactory $transitionHandlerFactory,
+        StateRepository $stateRepository,
+        Workflow $workflowA,
+        Workflow $workflowB,
+        Item $item
+    ) {
+        $workflowA->getName()->willReturn('workflow_a');
+        $workflowB->getName()->willReturn('workflow_b');
+
+        $this->beConstructedWith($transitionHandlerFactory, $stateRepository, [$workflowA, $workflowB]);
+
+        $entityId = EntityId::fromProviderNameAndId(static::ENTITY_PROVIDER_NAME, static::ENTITY_ID);
+
+        $item->getEntityId()->willReturn($entityId);
+        $item->getEntity()->willReturn(static::$entity);
+
+        $item->getWorkflowName()->willReturn('workflow_b');
+
+        $workflowA->supports($entityId, static::$entity)->willReturn(true);
+        $workflowB->supports($entityId, static::$entity)->willReturn(true);
+
+        $this->getWorkflowByItem($item)->shouldReturn($workflowB);
+    }
 }


### PR DESCRIPTION
The workflow manager checks each workflow if it supports an entity until it find the first matching one. It also happens if a workflow already started.

The new requirement is that an already started workflow should be preffered.

- [ ] Check first if an item is already assigned to a workflow and check if the workflow supports it
- [ ] If check fails checking all workflows as currently implemented
- [ ] New behaviour has to be configured by a flag to the workflow manager
- [ ] The `CachedManager` has to be deprecated as it's not worth to keep it after the changes