### PR TITLE
Equal and identical comparison are identical

### DIFF
--- a/spec/Util/ComparisonSpec.php
+++ b/spec/Util/ComparisonSpec.php
@@ -19,6 +19,8 @@ final class ComparisonSpec extends ObjectBehavior
     {
         $this->equals(1, 2)->shouldReturn(false);
         $this->equals(1, 1)->shouldReturn(true);
+        $this->equals(1, true)->shouldReturn(true);
+        $this->equals('1', true)->shouldReturn(true);
     }
 
     public function it_checks_if_values_not_equals(): void

--- a/src/Util/Comparison.php
+++ b/src/Util/Comparison.php
@@ -58,7 +58,7 @@ final class Comparison
      */
     public static function equals(mixed $valueA, mixed $valueB): bool
     {
-        return $valueA === $valueB;
+        return $valueA == $valueB;
     }
 
     /**


### PR DESCRIPTION
Hi David! 

While testing the develop branch of your Contao Workflow bundle, I stumbled upon the issue, that after editing an entity with workflow, no transitions were available, because the conditions weren't met. This was due to different types of the value of the  published field (`true` in the model vs. `'1'` in the condition). 

However, I then checked the comparison helper and saw that the two separate methods for equal and identical check [hjave the same implementation](https://github.com/netzmacht/workflow/blob/develop/src/Util/Comparison.php#L59-L75). I guess this was unintentional, so this PR fixes this :-)

(Introduced in ee4d9912363ebdd40d78d4d7bd8d71fcd9dc174f)

Best
Benedict